### PR TITLE
Implement basic microservice separation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # chamawebrest
+
+Este projeto demonstra uma aplicação PHP dividida em múltiplos microserviços.
+Cada script de API roda em seu próprio container Docker e as requisições são
+roteadas através de um gateway Nginx.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # chamawebrest
 
-Este projeto demonstra uma aplicação PHP dividida em múltiplos microserviços.
-Cada script de API roda em seu próprio container Docker e as requisições são
-roteadas através de um gateway Nginx.
+Este projeto demonstra uma aplicação PHP dividida em microserviços. Cada
+funcionalidade principal roda em seu próprio container Docker e todas as
+requisições passam por um gateway Nginx.
+
+Microserviços expostos:
+
+- **login** – telas de autenticação (index, login, logout, reset)
+- **dashboard** – listagem de chamados
+- **criar** – abertura de chamados
+- **admin** – painel administrativo e relatórios
+- **chamados**, **tickets**, **actions**, **stats** – APIs REST de suporte

--- a/api_tickets.php
+++ b/api_tickets.php
@@ -18,8 +18,9 @@ $headers = [
     "Authorization: Bearer " . API_TOKEN
 ];
 
+require_once 'inc/config.php';
 // Construir URL base da API
-$apiUrl = 'http://localhost:8080/api_chamados_rest.php';
+$apiUrl = rtrim(API_BASE_URL, '/') . '/api_chamados_rest.php';
 
 // Montar query string com filtros
 $queryParams = [];

--- a/criar_chamado.php
+++ b/criar_chamado.php
@@ -56,7 +56,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         'assigned_team_id' => !empty($assigned_team) ? $assigned_team : null
     ];
 
-    $ch = curl_init('http://localhost/api_chamados_rest.php');
+    require_once 'inc/config.php';
+    $apiEndpoint = rtrim(API_BASE_URL, '/') . '/api_chamados_rest.php';
+    $ch = curl_init($apiEndpoint);
     curl_setopt($ch, CURLOPT_VERBOSE, true); // Para debugar
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($ch, CURLOPT_POST, true);

--- a/dashboard.php
+++ b/dashboard.php
@@ -5,6 +5,7 @@ ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);
 
 require_once 'auth_token.php';
+require_once 'inc/config.php';
 
 // Verifica se o usuário está logado
 if (!isset($_SESSION['user_id'])) {
@@ -15,8 +16,7 @@ if (!isset($_SESSION['user_id'])) {
 $user_id = $_SESSION['user_id'];
 $role    = $_SESSION['role'];
 
-// Chamada à API
-$apiUrl = 'http://localhost:8080/api_chamados_rest.php';
+$apiUrl = rtrim(API_BASE_URL, '/') . '/api_chamados_rest.php';
 $ch = curl_init($apiUrl);
 
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
@@ -47,6 +47,7 @@ if ($role !== 'usuario') {
   <link rel="stylesheet" href="css/animations.css" />
   <link rel="stylesheet" href="css/enhanced.css" />
   <link rel="stylesheet" href="css/theme.css" />
+  <meta name="api-base-url" content="<?php echo API_BASE_URL; ?>">
 </head>
 <body>
 <header>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   admin:
     build: .
@@ -15,7 +13,6 @@ services:
       - actions
       - stats
       - db
-      - gateway
 
   chamados:
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,11 +10,41 @@ services:
     environment:
       API_URL: http://gateway
     depends_on:
-      - api
+      - chamados
+      - tickets
+      - actions
+      - stats
       - db
       - gateway
 
-  api:
+  chamados:
+    build: .
+    volumes:
+      - .:/var/www/html
+    expose:
+      - "80"
+    depends_on:
+      - db
+
+  tickets:
+    build: .
+    volumes:
+      - .:/var/www/html
+    expose:
+      - "80"
+    depends_on:
+      - db
+
+  actions:
+    build: .
+    volumes:
+      - .:/var/www/html
+    expose:
+      - "80"
+    depends_on:
+      - db
+
+  stats:
     build: .
     volumes:
       - .:/var/www/html
@@ -31,7 +61,10 @@ services:
       - "80:80"
     depends_on:
       - admin
-      - api
+      - chamados
+      - tickets
+      - actions
+      - stats
 
   db:
     image: mysql:5.7

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
 services:
   admin:
     build: .
-    ports:
-      - "8080:80"
     volumes:
       - .:/var/www/html
     environment:
@@ -12,6 +10,47 @@ services:
       - tickets
       - actions
       - stats
+      - db
+
+  dashboard:
+    build: .
+    volumes:
+      - .:/var/www/html
+    expose:
+      - "80"
+    environment:
+      API_URL: http://gateway
+    depends_on:
+      - chamados
+      - tickets
+      - actions
+      - stats
+      - db
+
+  criar:
+    build: .
+    volumes:
+      - .:/var/www/html
+    expose:
+      - "80"
+    environment:
+      API_URL: http://gateway
+    depends_on:
+      - chamados
+      - tickets
+      - actions
+      - stats
+      - db
+
+  login:
+    build: .
+    volumes:
+      - .:/var/www/html
+    expose:
+      - "80"
+    environment:
+      API_URL: http://gateway
+    depends_on:
       - db
 
   chamados:
@@ -57,6 +96,9 @@ services:
     ports:
       - "80:80"
     depends_on:
+      - login
+      - dashboard
+      - criar
       - admin
       - chamados
       - tickets

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,10 +8,11 @@ services:
     volumes:
       - .:/var/www/html
     environment:
-      API_URL: http://api
+      API_URL: http://gateway
     depends_on:
       - api
       - db
+      - gateway
 
   api:
     build: .
@@ -21,6 +22,16 @@ services:
       - "80"
     depends_on:
       - db
+
+  gateway:
+    image: nginx:alpine
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    ports:
+      - "80:80"
+    depends_on:
+      - admin
+      - api
 
   db:
     image: mysql:5.7

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,24 @@
 version: '3.8'
 
 services:
-  web:
+  admin:
     build: .
     ports:
       - "8080:80"
     volumes:
       - .:/var/www/html
+    environment:
+      API_URL: http://api
+    depends_on:
+      - api
+      - db
+
+  api:
+    build: .
+    volumes:
+      - .:/var/www/html
+    expose:
+      - "80"
     depends_on:
       - db
 

--- a/inc/config.php
+++ b/inc/config.php
@@ -1,0 +1,6 @@
+<?php
+// Base URL for API microservice
+if (!defined('API_BASE_URL')) {
+    define('API_BASE_URL', getenv('API_URL') ?: 'http://localhost:8080');
+}
+?>

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -4,6 +4,8 @@
  */
 
 document.addEventListener('DOMContentLoaded', function() {
+    const metaApi = document.querySelector('meta[name="api-base-url"]');
+    const API_BASE_URL = metaApi ? metaApi.content : '';
     // Instanciar contador para auto-refresh
     let autoRefreshTimer = null;
     let autoRefreshInterval = 60000; // 60 segundos
@@ -155,7 +157,7 @@ document.addEventListener('DOMContentLoaded', function() {
         if (teamSelect) params.append('team_id', teamSelect.value);
         
         // Fazer a requisição
-        fetch(`api_tickets.php?${params.toString()}`)
+        fetch(`${API_BASE_URL}/api_tickets.php?${params.toString()}`)
             .then(response => {
                 if (!response.ok) {
                     throw new Error('Erro na resposta: ' + response.status);

--- a/js/script.js
+++ b/js/script.js
@@ -1,4 +1,5 @@
 // Script principal para o Portal de Chamados
+const API_BASE_URL = document.querySelector('meta[name="api-base-url"]').content;
 document.addEventListener('DOMContentLoaded', function() {
     console.log("JS carregado!");
     
@@ -55,7 +56,7 @@ function setupDashboardFeatures() {
         if (pesquisaInput) params.append('pesquisa', pesquisaInput.value);
         if (teamSelect) params.append('team_id', teamSelect.value);
 
-        fetch('api_chamados_rest.php?' + params.toString(), {
+        fetch(API_BASE_URL + '/api_chamados_rest.php?' + params.toString(), {
             headers: {
                 'Authorization': 'Bearer admin123'
             }

--- a/nginx.conf
+++ b/nginx.conf
@@ -6,24 +6,22 @@ http {
     server {
         listen 80;
 
-        location = /api_chamados_rest.php {
-            proxy_pass http://chamados;
-        }
+        location = /login.php { proxy_pass http://login; }
+        location = /logout.php { proxy_pass http://login; }
+        location = /reset_password.php { proxy_pass http://login; }
 
-        location = /api_tickets.php {
-            proxy_pass http://tickets;
-        }
+        location = /dashboard.php { proxy_pass http://dashboard; }
+        location = /criar_chamado.php { proxy_pass http://criar; }
+        location = /admin.php { proxy_pass http://admin; }
+        location = /relatorios.php { proxy_pass http://admin; }
 
-        location = /api_tickets_actions.php {
-            proxy_pass http://actions;
-        }
-
-        location = /api_stats.php {
-            proxy_pass http://stats;
-        }
+        location = /api_chamados_rest.php { proxy_pass http://chamados; }
+        location = /api_tickets.php { proxy_pass http://tickets; }
+        location = /api_tickets_actions.php { proxy_pass http://actions; }
+        location = /api_stats.php { proxy_pass http://stats; }
 
         location / {
-            proxy_pass http://admin;
+            proxy_pass http://login;
         }
     }
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,17 @@
+worker_processes 1;
+
+events { worker_connections 1024; }
+
+http {
+    server {
+        listen 80;
+
+        location ~ ^/api_ {
+            proxy_pass http://api;
+        }
+
+        location / {
+            proxy_pass http://admin;
+        }
+    }
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -6,8 +6,20 @@ http {
     server {
         listen 80;
 
-        location ~ ^/api_ {
-            proxy_pass http://api;
+        location = /api_chamados_rest.php {
+            proxy_pass http://chamados;
+        }
+
+        location = /api_tickets.php {
+            proxy_pass http://tickets;
+        }
+
+        location = /api_tickets_actions.php {
+            proxy_pass http://actions;
+        }
+
+        location = /api_stats.php {
+            proxy_pass http://stats;
         }
 
         location / {


### PR DESCRIPTION
## Summary
- create config file for API base URL
- update web pages and scripts to use API_BASE_URL
- adjust curl calls to use new config
- add separate `api` service and rename `web` to `admin` in docker-compose

## Testing
- `php` command not available; no tests run

------
https://chatgpt.com/codex/tasks/task_e_6841d49838f083278fda166e27858413