### PR TITLE
Enable NodePort access to gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # chamawebrest
+
+## Kubernetes deployment
+
+A basic manifest is provided at `k8s/gateway-deployment.yaml` to run the application in a cluster. The service is exposed as a NodePort on **30080**. After applying the manifest you can reach the gateway at `http://<node-ip>:30080`.
+
+```bash
+kubectl apply -f k8s/gateway-deployment.yaml
+```
+

--- a/k8s/gateway-deployment.yaml
+++ b/k8s/gateway-deployment.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gateway
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gateway
+  template:
+    metadata:
+      labels:
+        app: gateway
+    spec:
+      containers:
+        - name: gateway
+          image: chamawebrest:latest
+          ports:
+            - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gateway
+spec:
+  type: NodePort
+  selector:
+    app: gateway
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+      nodePort: 30080


### PR DESCRIPTION
## Summary
- add Kubernetes deployment and service for gateway
- expose service using NodePort
- document NodePort usage in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846238ac7ac83279a2c18111dad3708