### PR TITLE
Add Kubernetes deployment and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
 # chamawebrest
+
+## Kubernetes
+
+A Kubernetes manifest is available at `k8s/web-deployment.yaml`. It creates a
+Deployment and a Service that mirror the Docker Compose setup and expose
+container port `80`.
+
+### Running on Minikube
+
+1. Build the image inside the Minikube Docker daemon and apply the manifest:
+
+   ```bash
+   eval $(minikube -p minikube docker-env)
+   docker build -t chamawebrest:latest .
+   kubectl apply -f k8s/web-deployment.yaml
+   ```
+
+2. Access the web portal using one of the methods below:
+
+   * **NodePort:** start Minikube allowing access on `localhost:8080` and open
+     the service:
+
+     ```bash
+     minikube start --ports=8080:30080
+     # after the pods are running
+     http://localhost:8080
+     ```
+
+   * **Port forward:** if you prefer not to use a NodePort, run:
+
+     ```bash
+     kubectl port-forward svc/web 8080:80
+     ```
+
+     then browse to `http://localhost:8080`.

--- a/k8s/web-deployment.yaml
+++ b/k8s/web-deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+      - name: web
+        image: chamawebrest:latest
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+spec:
+  type: NodePort
+  selector:
+    app: web
+  ports:
+  - port: 80
+    targetPort: 80
+    nodePort: 30080


### PR DESCRIPTION
## Summary
- add Deployment/Service YAML to deploy the web container
- document how to access the service via NodePort or port-forward

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846238792f8832792da2ef644e33c1f